### PR TITLE
Added Azure Storage Accounts as data and message exchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Beside of cloning this repo please consider following requirements:
 
 
 * **Azure account**  
-  To run only locally no azure account is required. However to scale out API module with [CosmosDB](https://azure.microsoft.com/de-de/services/cosmos-db/) or to use the [Azure Service Bus](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview) you require a azure account ([free accounts available](https://azure.microsoft.com/en-us/free) for dev purposes).
+  To run only locally no azure account is required. 
+* However to scale out API module with [CosmosDB](https://azure.microsoft.com/de-de/services/cosmos-db/) 
+* or to use [Azure Service Bus](https://docs.microsoft.com/en-us/azure/service-bus-messaging/service-bus-messaging-overview) or Azure Storage account you require a azure account ([free accounts available](https://azure.microsoft.com/en-us/free) for dev purposes).
 
 
 # Usage
@@ -181,11 +183,13 @@ The following settings are required/supported in the apps:
 * SAPHub.Server:
   - SAP Connection (required)
   - Message Exchange (optional)
+  - Data Exchange (optional)
   - CosmosDb (optional)
   - URL endpoints (optional)
 
 * SAPHub.ApiEndpoint:
   - Message Exchange (required)
+  - Data Exchange (required)
   - CosmosDb (optional, required to scale)
   - URL endpoints (required)
 
@@ -194,6 +198,7 @@ The following settings are required/supported in the apps:
 
 * SAPHub.SAPConnector:
   - Message Exchange (required)
+  - Data Exchange (required)
   - SAP Connection (required)
 
 ### URL Endpoint configuration
@@ -254,6 +259,14 @@ The API Module and the SAP Connector module communicate asynchronously via a mes
   { "bus" : { "type" : "inmemory" } }
   ``` 
 
+- **Azure Storage Account**  
+  Uses Azure Storage Account Queues as message exchange.
+
+  **Configuration**:
+
+  ``` json
+  { "bus" : { "type" : "azurestorage", "connectionstring": "" } }
+  ``` 
 
 - **Azure Service Bus**  
   Uses a Azure Service Bus as message exchange. 
@@ -272,6 +285,39 @@ The API Module and the SAP Connector module communicate asynchronously via a mes
   ``` json
   { "bus" : { "type" : "rabbitmq", "connectionstring": "" } }
   ``` 
+
+### Data Exchanges
+To transfer large data (results) between the API module and the SAP connector a data exchange is required. The following data exchanges are supported:
+
+- **In-Memory**  
+  Supports only the communication between modules hosted in same process.
+
+  The in-memory exchange is automatically used in the SAPHub.Server app and only makes sense if you run one single instance of SAPHub.Server.
+
+  **Configuration**:
+
+  ``` json
+  { "databus" : { "type" : "inmemory" } }
+  ``` 
+
+- **Azure Storage Account**  
+  Uses Azure Storage Account Blobs as data exchange.
+
+  **Configuration**:
+
+  ``` json
+  { "databus" : { "type" : "azurestorage", "connectionstring": "", "container": "saphub" } }
+  ``` 
+
+- **File System**  
+  Uses a path on the filesystem as data exchange (makes only sense if SAP Connector and API Module could access the path.
+
+  **Configuration**:
+
+  ``` json
+  { "databus" : { "type" : "filesystem", "path": "\\\\somehost\\some_share" } }
+  ``` 
+
 
 ### Azure Cosmos DB
 To scale out the API Module (by starting multiple SAPHub.APIEndpoint or SAPHub.Server apps) you have to enable the Azure Cosmos DB as shared DB storage for the API endpoints. 

--- a/SAPHub.sln.DotSettings
+++ b/SAPHub.sln.DotSettings
@@ -1,12 +1,15 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SAP/@EntryIndexedValue">SAP</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=accountkey/@EntryIndexedValue">True</s:Boolean>
+s	<s:Boolean x:Key="/Default/UserDictionary/Words/=azureblobs/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=azurequeue/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=azureservicebus/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=azurestorage/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=companycodes/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Configurer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=connectionstring/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=cosmosdb/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=databus/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=inmemory/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=rabbitmq/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=SAPHUB/@EntryIndexedValue">True</s:Boolean>

--- a/src/SAPHub.ApiEndpoint/Program.cs
+++ b/src/SAPHub.ApiEndpoint/Program.cs
@@ -19,7 +19,7 @@ namespace SAPHub
         {
             //setup shared ServiceProvider
             var services = new ServiceCollection()
-                .AddTransportSelector()  // chooses Rebus transport by configuration
+                .AddRebusSelectors()  // chooses Rebus transport by configuration
                 .AddStateDb();           // required for state store in API module 
 
             // create ModulesHosts with ASPNetCore enabled and host API module

--- a/src/SAPHub.ApiModule/ApiModule.cs
+++ b/src/SAPHub.ApiModule/ApiModule.cs
@@ -76,16 +76,22 @@ namespace SAPHub.ApiModule
                     {
                         x.TypeBased()
                             .Map(typeof(GetCompanyCodesCommand), QueueNames.SAPConnector)
-                            .Map(typeof(GetCompanyCodeCommand), QueueNames.SAPConnector);
+                            .Map(typeof(GetCompanyCodeCommand), QueueNames.SAPConnector)
+                            .Map<OperationStatusEvent>(QueueNames.Api);
+                        
                     })
                     .Options(x =>
                     {
                         x.SimpleRetryStrategy();
                         x.SetNumberOfWorkers(5);
                     })
+                    .DataBus(ds => sp.GetRequiredService<IRebusDataBusConfigurer>()
+                        .Configure(ds)
+                    )
                     .Subscriptions(s => sp.GetRequiredService<IRebusSubscriptionConfigurer>().Configure(s))
                     .Serialization(x => x.UseNewtonsoftJson(new JsonSerializerSettings
                         { TypeNameHandling = TypeNameHandling.None }))
+                    .Timeouts(cfg => sp.GetRequiredService<IRebusTimeoutConfigurer>().Configure(cfg))
                     .Logging(x => x.ColoredConsole());
 
             }, onCreated: bus => bus.Subscribe(typeof(OperationStatusEvent)));

--- a/src/SAPHub.ApiModule/OperationStatusEventHandler.cs
+++ b/src/SAPHub.ApiModule/OperationStatusEventHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
 using Rebus.Handlers;
@@ -32,8 +33,14 @@ namespace SAPHub.ApiModule
             
             op.Status = message.Status;
             op.StatusMessage = message.StatusMessage;
-            op.ResultData = message.ResultData;
             op.ResultType = message.ResultType;
+
+            if (message.Attachment != null)
+            {
+                await using var dataStream = await message.Attachment.OpenRead();
+                using var reader = new StreamReader(dataStream);
+                op.ResultData = await reader.ReadToEndAsync();
+            }
 
             await _repository.UpdateAsync(op);
         }

--- a/src/SAPHub.Common/Bus/IRebusDataBusConfigurer.cs
+++ b/src/SAPHub.Common/Bus/IRebusDataBusConfigurer.cs
@@ -1,0 +1,10 @@
+using Rebus.Config;
+using Rebus.DataBus;
+
+namespace SAPHub.Bus
+{
+    public interface IRebusDataBusConfigurer
+    {
+        void Configure(StandardConfigurer<IDataBusStorage> configurer);
+    }
+}

--- a/src/SAPHub.Common/Bus/IRebusTimeoutConfigurer.cs
+++ b/src/SAPHub.Common/Bus/IRebusTimeoutConfigurer.cs
@@ -1,0 +1,10 @@
+using Rebus.Config;
+using Rebus.Timeouts;
+
+namespace SAPHub.Bus
+{
+    public interface IRebusTimeoutConfigurer
+    {
+        void Configure(StandardConfigurer<ITimeoutManager> configurer);
+    }
+}

--- a/src/SAPHub.Common/Bus/QueueNames.cs
+++ b/src/SAPHub.Common/Bus/QueueNames.cs
@@ -2,7 +2,7 @@
 {
     public class QueueNames
     {
-        public const string SAPConnector = "SAPConnectorModule";
-        public const string Api = "ApiModule";
+        public const string SAPConnector = "sapconnector";
+        public const string Api = "apimodule";
     }
 }

--- a/src/SAPHub.Common/Messages/Command.cs
+++ b/src/SAPHub.Common/Messages/Command.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Rebus.DataBus;
 
 namespace SAPHub.Messages
 {
@@ -9,7 +10,7 @@ namespace SAPHub.Messages
 
         public OperationStatus Status { get; set; }
 
-        public string ResultData { get; set; }
+        public DataBusAttachment Attachment { get; set; }
         public string ResultType { get; set; }
 
         public string StatusMessage { get; set; }

--- a/src/SAPHub.ConnectorModule/SAPConnectorModule.cs
+++ b/src/SAPHub.ConnectorModule/SAPConnectorModule.cs
@@ -8,13 +8,12 @@ using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json;
 using Rebus.Config;
 using Rebus.Handlers;
-using Rebus.Persistence.InMem;
 using Rebus.Retry.Simple;
+using Rebus.Routing.TypeBased;
 using Rebus.Serialization.Json;
-using Rebus.ServiceProvider;
 using SAPHub.Bus;
 using SAPHub.ConnectorModule.CommandHandlers;
-using Exception = System.Exception;
+using SAPHub.Messages;
 
 namespace SAPHub.ConnectorModule
 {
@@ -34,20 +33,24 @@ namespace SAPHub.ConnectorModule
             services.AddRebus(configurer =>
             {
                 return configurer
+                    .Routing(x=> x.TypeBased().Map<OperationStatusEvent>(QueueNames.Api))
                     .Transport(t =>
                         sp.GetRequiredService<IRebusTransportConfigurer>().Configure(t, QueueNames.SAPConnector))
-                    
+
                     .Options(x =>
                     {
-                        x.SimpleRetryStrategy(maxDeliveryAttempts:1,
+                        x.SimpleRetryStrategy(maxDeliveryAttempts: 1,
                             secondLevelRetriesEnabled: true);
-                        
+
                         x.SetNumberOfWorkers(2); // restrict to 2 workers for each Instance
                     })
+                    .DataBus(ds => sp.GetRequiredService<IRebusDataBusConfigurer>()
+                        .Configure(ds)
+                    )
                     .Subscriptions(s => sp.GetRequiredService<IRebusSubscriptionConfigurer>().Configure(s))
                     .Serialization(x => x.UseNewtonsoftJson(new JsonSerializerSettings
-                        {TypeNameHandling = TypeNameHandling.None}))
-                    .Timeouts(cfg => cfg.StoreInMemory())
+                        { TypeNameHandling = TypeNameHandling.None }))
+                    .Timeouts(cfg => sp.GetRequiredService<IRebusTimeoutConfigurer>().Configure(cfg))
                     .Logging(x => x.ColoredConsole());
             });
 

--- a/src/SAPHub.MessageBus/AzureTablesSubscriptionConfigurationExtensions.cs
+++ b/src/SAPHub.MessageBus/AzureTablesSubscriptionConfigurationExtensions.cs
@@ -1,0 +1,92 @@
+using System;
+using Azure.Core;
+using Azure.Data.Tables;
+using Rebus.Config;
+using Rebus.Subscriptions;
+
+namespace SAPHub.MessageBus
+{
+    /// <summary>
+    /// Configuration extensions for subcriptions storage in Azure Cosmos Db Tables or Azure Table Storage
+    /// </summary>
+    public static class AzureTablesSubscriptionConfigurationExtensions
+    {
+        /// <summary>
+        /// Configure Rebus to store subscriptions in Azure Cosmos Db Tables or Azure Table Storage
+        /// </summary>
+        /// <param name="configurer"></param>
+        /// <param name="connectionString">Azure Cosmos Db Tables or Azure Table Storage connection string including key</param>
+        /// <param name="tableName">Name of the table where the subscriptions will be stored </param>
+        /// <param name="isCentralized">True if this subscription storage is centralized (i.e. if subscribers can register themselves directly)</param>
+        /// <param name="automaticallyCreateTable">True if the storage table should be created if not exist</param>
+        /// <exception cref="ArgumentNullException">Thrown when not all mandatory parameters are provided</exception>
+        public static void StoreInAzureTables(this StandardConfigurer<ISubscriptionStorage> configurer,
+            string connectionString, string tableName = "RebusSubscriptions", bool isCentralized = false,
+            bool automaticallyCreateTable = false)
+        {
+            if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
+
+            configurer.StoreInAzureTables(new TableServiceClient(connectionString), tableName, isCentralized,
+                automaticallyCreateTable);
+        }
+
+        /// <summary>
+        /// Configure Rebus to store subscriptions in Azure Cosmos Db Tables or Azure Table Storage
+        /// </summary>
+        /// <param name="configurer"></param>
+        /// <param name="serviceEndpoint">Azure Cosmos Db Tables or Azure Table Storage service endpoint</param>
+        /// <param name="credential">Credetial for authentication to Azure service (eg. new DefaultAzureCredential())</param>
+        /// <param name="tableName">Name of the table where the subscriptions will be stored </param>
+        /// <param name="isCentralized">True if this subscription storage is centralized (i.e. if subscribers can register themselves directly)</param>
+        /// <param name="automaticallyCreateTable">True if the storage table should be created if not exist</param>
+        /// <exception cref="ArgumentNullException">Thrown when not all mandatory parameters are provided</exception>
+        public static void StoreInAzureTables(this StandardConfigurer<ISubscriptionStorage> configurer,
+            Uri serviceEndpoint, TokenCredential credential, string tableName = "RebusSubscriptions",
+            bool isCentralized = false, bool automaticallyCreateTable = false)
+        {
+            if (serviceEndpoint == null) throw new ArgumentNullException(nameof(serviceEndpoint));
+            if (credential == null) throw new ArgumentNullException(nameof(credential));
+
+            configurer.StoreInAzureTables(new TableServiceClient(serviceEndpoint, credential), tableName, isCentralized,
+                automaticallyCreateTable);
+        }
+
+        /// <summary>
+        /// Configure Rebus to store subscriptions in Azure Cosmos Db Tables or Azure Table Storage
+        /// </summary>
+        /// <param name="configurer"></param>
+        /// <param name="tableServiceClient">Azure Cosmos Db Tables or Azure Table Storage TableServiceClient</param>
+        /// <param name="tableName">Name of the table where the subscriptions will be stored </param>
+        /// <param name="isCentralized">True if this subscription storage is centralized (i.e. if subscribers can register themselves directly)</param>
+        /// <param name="automaticallyCreateTable">True if the storage table should be created if not exist</param>
+        /// <exception cref="ArgumentNullException">Thrown when not all mandatory parameters are provided</exception>
+        public static void StoreInAzureTables(this StandardConfigurer<ISubscriptionStorage> configurer,
+            TableServiceClient tableServiceClient, string tableName = "RebusSubscriptions", bool isCentralized = false,
+            bool automaticallyCreateTable = false)
+        {
+            if (tableServiceClient == null) throw new ArgumentNullException(nameof(tableServiceClient));
+            if (tableName == null) throw new ArgumentNullException(nameof(tableName));
+
+            configurer.StoreInAzureTables(tableServiceClient.GetTableClient(tableName), isCentralized,
+                automaticallyCreateTable);
+        }
+
+        /// <summary>
+        /// Configure Rebus to store subscriptions in Azure Cosmos Db Tables or Azure Table Storage
+        /// </summary>
+        /// <param name="configurer"></param>
+        /// <param name="tableClient">Azure Cosmos Db Tables or Azure Table Storage TableClient</param>
+        /// <param name="isCentralized">True if this subscription storage is centralized (i.e. if subscribers can register themselves directly)</param>
+        /// <param name="automaticallyCreateTable">True if the storage table should be created if not exist</param>
+        /// <exception cref="ArgumentNullException">Thrown when not all mandatory parameters are provided</exception>
+        public static void StoreInAzureTables(this StandardConfigurer<ISubscriptionStorage> configurer,
+            TableClient tableClient, bool isCentralized = false, bool automaticallyCreateTable = false)
+        {
+            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+            if (tableClient == null) throw new ArgumentNullException(nameof(tableClient));
+
+            configurer.Register(context =>
+                new AzureTablesSubscriptionStorage(tableClient, isCentralized, automaticallyCreateTable));
+        }
+    }
+}

--- a/src/SAPHub.MessageBus/AzureTablesSubscriptionStorage.cs
+++ b/src/SAPHub.MessageBus/AzureTablesSubscriptionStorage.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Azure;
+using Azure.Data.Tables;
+using Rebus.Bus;
+using Rebus.Exceptions;
+using Rebus.Subscriptions;
+
+namespace SAPHub.MessageBus
+{
+    public class AzureTablesSubscriptionStorage : ISubscriptionStorage, IInitializable {
+        private readonly TableClient _tableClient;
+        private readonly bool _automaticallyCreateTable;
+        private bool _tableInitialized;
+
+        /// <summary>
+        /// Creates the subscription storage
+        /// </summary>
+        public AzureTablesSubscriptionStorage(TableClient tableClient, bool isCentralized = false, bool automaticallyCreateTable = false) {
+            _tableClient = tableClient;
+            IsCentralized = isCentralized;
+            _automaticallyCreateTable = automaticallyCreateTable;
+        }
+
+        /// <summary>
+        /// Initializes the subscription storage by ensuring that the necessary table is created
+        /// </summary>
+        public void Initialize() => GetTableClient().Wait();
+
+        /// <summary>
+        /// Gets all subscribers by getting row IDs from the partition named after the given <paramref name="topic"/>
+        /// </summary>
+        public async Task<string[]> GetSubscriberAddresses(string topic) {
+            try {
+                var client = await GetTableClient();
+                var items = client.QueryAsync<TableEntity>(s => s.PartitionKey == topic, select: new[] { "PartitionKey", "RowKey" });
+                var addresses = new List<string>();
+                await foreach (var address in items)
+                    addresses.Add(address.RowKey);
+                return addresses.ToArray();
+            }
+            catch (RequestFailedException ex) {
+                throw new RebusApplicationException(ex, $"Could not get subscriber addresses for '{topic}'");
+            }
+        }
+
+        /// <summary>
+        /// Registers the given <paramref name="subscriberAddress"/> as a subscriber of the topic named <paramref name="topic"/>
+        /// by inserting a row with the address as the row ID under a partition key named after the topic
+        /// </summary>
+        public async Task RegisterSubscriber(string topic, string subscriberAddress) {
+            try {
+                var client = await GetTableClient();
+                await client.UpsertEntityAsync(new TableEntity(topic, subscriberAddress));
+            }
+            catch (RequestFailedException ex) {
+                throw new RebusApplicationException(ex, $"Could not subscriber {subscriberAddress} to '{topic}'");
+            }
+        }
+
+        /// <summary>
+        /// Unregisters the given <paramref name="subscriberAddress"/> as a subscriber of the topic named <paramref name="topic"/>
+        /// by removing the row with the address as the row ID under a partition key named after the topic
+        /// </summary>
+        public async Task UnregisterSubscriber(string topic, string subscriberAddress) {
+            try {
+                var client = await GetTableClient();
+                await client.DeleteEntityAsync(topic, subscriberAddress);
+            }
+            catch (RequestFailedException ex) {
+                throw new RebusApplicationException(ex, $"Could not subscriber {subscriberAddress} to '{topic}'");
+            }
+        }
+
+        /// <summary>
+        /// Gets whether this subscription storage is centralized (i.e. whether subscribers can register themselves directly)
+        /// </summary>
+        public bool IsCentralized { get; }
+
+        private async Task<TableClient> GetTableClient() {
+            if (_automaticallyCreateTable && !_tableInitialized)
+                try {
+                    await _tableClient.CreateIfNotExistsAsync();
+                    _tableInitialized = true;
+                }
+                catch (RequestFailedException ex) {
+                    throw new RebusApplicationException(ex, $"Could not create table '{_tableClient.Name}' for storing subscriptions");
+                }
+
+            return _tableClient;
+        }
+    }
+}

--- a/src/SAPHub.MessageBus/ConfigAzureTablesSubscriptionConfigurationExtensions.cs
+++ b/src/SAPHub.MessageBus/ConfigAzureTablesSubscriptionConfigurationExtensions.cs
@@ -1,0 +1,90 @@
+using System;
+using Azure.Core;
+using Azure.Data.Tables;
+using Rebus.Config;
+using Rebus.Subscriptions;
+using SAPHub.MessageBus;
+
+/// <summary>
+/// Configuration extensions for subcriptions storage in Azure Cosmos Db Tables or Azure Table Storage
+/// </summary>
+public static class ConfigAzureTablesSubscriptionConfigurationExtensions
+{
+    /// <summary>
+    /// Configure Rebus to store subscriptions in Azure Cosmos Db Tables or Azure Table Storage
+    /// </summary>
+    /// <param name="configurer"></param>
+    /// <param name="connectionString">Azure Cosmos Db Tables or Azure Table Storage connection string including key</param>
+    /// <param name="tableName">Name of the table where the subscriptions will be stored </param>
+    /// <param name="isCentralized">True if this subscription storage is centralized (i.e. if subscribers can register themselves directly)</param>
+    /// <param name="automaticallyCreateTable">True if the storage table should be created if not exist</param>
+    /// <exception cref="ArgumentNullException">Thrown when not all mandatory parameters are provided</exception>
+    public static void StoreInAzureTables(this StandardConfigurer<ISubscriptionStorage> configurer,
+        string connectionString, string tableName = "RebusSubscriptions", bool isCentralized = false,
+        bool automaticallyCreateTable = false)
+    {
+        if (connectionString == null) throw new ArgumentNullException(nameof(connectionString));
+
+        configurer.StoreInAzureTables(new TableServiceClient(tableName), tableName, isCentralized,
+            automaticallyCreateTable);
+    }
+
+    /// <summary>
+    /// Configure Rebus to store subscriptions in Azure Cosmos Db Tables or Azure Table Storage
+    /// </summary>
+    /// <param name="configurer"></param>
+    /// <param name="serviceEndpoint">Azure Cosmos Db Tables or Azure Table Storage service endpoint</param>
+    /// <param name="credential">Credetial for authentication to Azure service (eg. new DefaultAzureCredential())</param>
+    /// <param name="tableName">Name of the table where the subscriptions will be stored </param>
+    /// <param name="isCentralized">True if this subscription storage is centralized (i.e. if subscribers can register themselves directly)</param>
+    /// <param name="automaticallyCreateTable">True if the storage table should be created if not exist</param>
+    /// <exception cref="ArgumentNullException">Thrown when not all mandatory parameters are provided</exception>
+    public static void StoreInAzureTables(this StandardConfigurer<ISubscriptionStorage> configurer, Uri serviceEndpoint,
+        TokenCredential credential, string tableName = "RebusSubscriptions", bool isCentralized = false,
+        bool automaticallyCreateTable = false)
+    {
+        if (serviceEndpoint == null) throw new ArgumentNullException(nameof(serviceEndpoint));
+        if (credential == null) throw new ArgumentNullException(nameof(credential));
+
+        configurer.StoreInAzureTables(new TableServiceClient(serviceEndpoint, credential), tableName, isCentralized,
+            automaticallyCreateTable);
+    }
+
+    /// <summary>
+    /// Configure Rebus to store subscriptions in Azure Cosmos Db Tables or Azure Table Storage
+    /// </summary>
+    /// <param name="configurer"></param>
+    /// <param name="tableServiceClient">Azure Cosmos Db Tables or Azure Table Storage TableServiceClient</param>
+    /// <param name="tableName">Name of the table where the subscriptions will be stored </param>
+    /// <param name="isCentralized">True if this subscription storage is centralized (i.e. if subscribers can register themselves directly)</param>
+    /// <param name="automaticallyCreateTable">True if the storage table should be created if not exist</param>
+    /// <exception cref="ArgumentNullException">Thrown when not all mandatory parameters are provided</exception>
+    public static void StoreInAzureTables(this StandardConfigurer<ISubscriptionStorage> configurer,
+        TableServiceClient tableServiceClient, string tableName = "RebusSubscriptions", bool isCentralized = false,
+        bool automaticallyCreateTable = false)
+    {
+        if (tableServiceClient == null) throw new ArgumentNullException(nameof(tableServiceClient));
+        if (tableName == null) throw new ArgumentNullException(nameof(tableName));
+
+        configurer.StoreInAzureTables(tableServiceClient.GetTableClient(tableName), isCentralized,
+            automaticallyCreateTable);
+    }
+
+    /// <summary>
+    /// Configure Rebus to store subscriptions in Azure Cosmos Db Tables or Azure Table Storage
+    /// </summary>
+    /// <param name="configurer"></param>
+    /// <param name="tableClient">Azure Cosmos Db Tables or Azure Table Storage TableClient</param>
+    /// <param name="isCentralized">True if this subscription storage is centralized (i.e. if subscribers can register themselves directly)</param>
+    /// <param name="automaticallyCreateTable">True if the storage table should be created if not exist</param>
+    /// <exception cref="ArgumentNullException">Thrown when not all mandatory parameters are provided</exception>
+    public static void StoreInAzureTables(this StandardConfigurer<ISubscriptionStorage> configurer,
+        TableClient tableClient, bool isCentralized = false, bool automaticallyCreateTable = false)
+    {
+        if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+        if (tableClient == null) throw new ArgumentNullException(nameof(tableClient));
+
+        configurer.Register(context =>
+            new AzureTablesSubscriptionStorage(tableClient, isCentralized, automaticallyCreateTable));
+    }
+}

--- a/src/SAPHub.MessageBus/RebusDataBusSelector.cs
+++ b/src/SAPHub.MessageBus/RebusDataBusSelector.cs
@@ -1,0 +1,77 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Rebus.Config;
+using Rebus.DataBus;
+using Rebus.DataBus.FileSystem;
+using Rebus.DataBus.InMem;
+using SAPHub.Bus;
+
+namespace SAPHub.MessageBus
+{
+  public class RebusDataBusSelector : IRebusDataBusConfigurer
+  {
+    private readonly string _busType;
+    private readonly string _connectionString;
+    private readonly string _path;
+    private readonly string _containerName;
+    private readonly InMemDataStore _dataStore;
+    private ILogger _logger;
+
+
+    public RebusDataBusSelector(IConfiguration configuration, InMemDataStore dataStore,
+      ILogger<RebusDataBusSelector> logger)
+    {
+      _dataStore = dataStore;
+      _logger = logger;
+
+      _busType = configuration["databus:type"];
+      _connectionString = configuration["databus:connectionstring"];
+      _path = configuration["databus:path"];
+      _containerName = configuration["databus:container"];
+
+      if (_busType == null)
+        throw new InvalidOperationException(
+          "Missing configuration entry for databus::type. Configure a valid bus type (inmemory,filesystem,azureblobs");
+
+      switch (_busType)
+      {
+        case "azureblobs":
+          if (_connectionString == null)
+            throw new InvalidOperationException("Missing configuration entry for databus::connectionstring.");
+          if (_containerName == null)
+            throw new InvalidOperationException("Missing configuration entry for databus::container.");
+          return;
+
+        case "filesystem":
+          if (_path == null)
+            throw new InvalidOperationException("Missing configuration entry for databus::path.");
+          return;
+
+        case "inmemory": return;
+
+      }
+
+      throw new InvalidOperationException(
+        $"Invalid bus type: {_busType} .Configure a valid bus type (inmemory,rabbitmq,azureservicebus).");
+
+    }
+
+
+    public void Configure(StandardConfigurer<IDataBusStorage> configurer)
+    {
+      switch (_busType)
+      {
+        case "azureblobs":
+          configurer.StoreInBlobStorage(_connectionString, _containerName);
+          break;
+        case "filesystem":
+          configurer.StoreInFileSystem(_path);
+          break;
+        case "inmemory":
+          configurer.StoreInMemory(_dataStore);
+          break;
+      }
+    }
+  }
+}

--- a/src/SAPHub.MessageBus/RebusTimeoutSelector.cs
+++ b/src/SAPHub.MessageBus/RebusTimeoutSelector.cs
@@ -1,0 +1,49 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Rebus.Config;
+using Rebus.Persistence.InMem;
+using Rebus.Timeouts;
+using Rebus.Transport.InMem;
+using SAPHub.Bus;
+
+namespace SAPHub.MessageBus
+{
+    public class RebusTimeoutSelector : IRebusTimeoutConfigurer
+    {
+        private readonly string _busType;
+
+        public RebusTimeoutSelector(IConfiguration configuration)
+        {
+
+            _busType = configuration["bus:type"];
+            
+            switch (_busType)
+            {
+                case "azurestorage":
+                case "azureservicebus":
+                case "rabbitmq":
+                case "inmemory": return;
+
+            }
+
+            throw new InvalidOperationException($"Invalid bus type: {_busType} .Configure a valid bus type (inmemory,rabbitmq,azurestorage,azureservicebus).");
+
+        }
+
+         
+        public void Configure(StandardConfigurer<ITimeoutManager> configurer)
+        {
+            switch (_busType)
+            {
+                case "azurestorage":
+                case "azureservicebus":
+                case "rabbitmq":
+                    return;  // these all have native timeout support
+                case "inmemory": 
+                    configurer.StoreInMemory();
+                    return;
+            }
+        }
+    }
+}

--- a/src/SAPHub.MessageBus/RebusTransportSelector.cs
+++ b/src/SAPHub.MessageBus/RebusTransportSelector.cs
@@ -28,10 +28,11 @@ namespace SAPHub.MessageBus
             _connectionString = configuration["bus:connectionstring"]; 
 
             if (_busType == null)
-                throw new InvalidOperationException("Missing configuration entry for bus::type. Configure a valid bus type (inmemory,rabbitmq,azureservicebus");
+                throw new InvalidOperationException("Missing configuration entry for bus::type. Configure a valid bus type (inmemory,rabbitmq,azurestorage,azureservicebus");
 
             switch (_busType)
             {
+                case "azurestorage":
                 case "azureservicebus":
                 case "rabbitmq":
                     if (_connectionString == null)
@@ -42,7 +43,7 @@ namespace SAPHub.MessageBus
 
             }
 
-            throw new InvalidOperationException($"Invalid bus type: {_busType} .Configure a valid bus type (inmemory,rabbitmq,azureservicebus).");
+            throw new InvalidOperationException($"Invalid bus type: {_busType} .Configure a valid bus type (inmemory,rabbitmq,azurestorage,azureservicebus).");
 
         }
 
@@ -51,6 +52,10 @@ namespace SAPHub.MessageBus
             
             switch (_busType)
             {
+                case "azurestorage":
+                    configurer.UseAzureStorageQueuesAsOneWayClient(_connectionString);
+                        
+                    break;
                 case "azureservicebus":
                     configurer.UseAzureServiceBusAsOneWayClient(_connectionString);
                         
@@ -72,6 +77,10 @@ namespace SAPHub.MessageBus
         {
             switch (_busType)
             {
+                case "azurestorage":
+                    configurer.UseAzureStorageQueues(_connectionString, queueName);
+                        
+                    break;
                 case "azureservicebus":
                     configurer.UseAzureServiceBus(_connectionString,queueName);
                     break;

--- a/src/SAPHub.MessageBus/SAPHub.MessageBus.csproj
+++ b/src/SAPHub.MessageBus/SAPHub.MessageBus.csproj
@@ -8,7 +8,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Rebus.AzureBlobs" Version="0.6.0" />
+    <PackageReference Include="Rebus.AzureQueues" Version="3.0.0" />
     <PackageReference Include="Rebus.AzureServiceBus" Version="9.1.0" />
+    <PackageReference Include="Rebus.AzureTables" Version="0.0.4" />
     <PackageReference Include="Rebus.RabbitMq" Version="7.4.2" />
   </ItemGroup>
 

--- a/src/SAPHub.MessageBus/ServiceCollectionExtensions.cs
+++ b/src/SAPHub.MessageBus/ServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Rebus.DataBus.InMem;
 using Rebus.Persistence.InMem;
 using Rebus.Transport.InMem;
 using SAPHub.Bus;
@@ -7,13 +8,17 @@ namespace SAPHub.MessageBus
 {
     public static class ServiceCollectionExtensions
     {
-        public static IServiceCollection AddTransportSelector(this IServiceCollection services)
+        public static IServiceCollection AddRebusSelectors(this IServiceCollection services)
         {
             services.AddSingleton(new InMemNetwork(true));
             services.AddSingleton(new InMemorySubscriberStore());
             services.AddSingleton<IRebusTransportConfigurer, RebusTransportSelector>();
-            services.AddSingleton<IRebusSubscriptionConfigurer, InMemorySubscriptionConfigurer>();
-
+            services.AddSingleton<IRebusSubscriptionConfigurer, SubscriptionStoreSelector>();
+            services.AddSingleton<IRebusTimeoutConfigurer, RebusTimeoutSelector>();
+            
+            services.AddSingleton(new InMemDataStore());
+            services.AddSingleton<IRebusDataBusConfigurer, RebusDataBusSelector>();
+            
             return services;
         }
 

--- a/src/SAPHub.SAPConnector/Program.cs
+++ b/src/SAPHub.SAPConnector/Program.cs
@@ -22,7 +22,7 @@ namespace SAPHub.SAPConnector
         {
             //setup shared ServiceProvider
             var services = new ServiceCollection()
-                .AddTransportSelector();    // chooses Rebus transport by configuration
+                .AddRebusSelectors();    // chooses Rebus transport by configuration
 
             // create ModulesHosts and host SAPConnector module
             return ModulesHost.CreateDefaultBuilder(args)

--- a/src/SAPHub.Server/Program.cs
+++ b/src/SAPHub.Server/Program.cs
@@ -27,13 +27,14 @@ namespace SAPHub
         {
             //setup shared ServiceProvider
             var services = new ServiceCollection()
-                .AddTransportSelector()  // chooses Rebus transport by configuration
+                .AddRebusSelectors()  // chooses Rebus transport by configuration
                 .AddStateDb();           // required for state store in API module
 
             // set default Rebus transport to inmemory
             var staticSettings = new Dictionary<string,string>
             {
-                ["bus:type"] ="inmemory"
+                ["bus:type"] ="inmemory",
+                ["databus:type"] ="inmemory"
             };
 
             // create ModulesHosts and host SAPConnector module


### PR DESCRIPTION
Azure Storage accounts can now be used as message exchange (queue exchange).

In addition a data bus will now be used to transfer the data. This will be either inmemory, filesystem or a azure storage account (blob storage). 